### PR TITLE
Fixed path to index.js in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jpeg-exif",
   "version": "1.1.1",
   "description": "Use for parse .jpg file exif info (including GPS info.).",
-  "main": "index.js",
+  "main": "lib/index.js",
   "scripts": {
     "test": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha -report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "lint": "./node_modules/.bin/eslint ./src/index.js ./test/index.test.js --fix",


### PR DESCRIPTION
Get an error "Error: Cannot find module 'jpeg-exif'" when requiring this module when the path is incorrect.