### PR TITLE
Added fromBuffer documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,24 @@ exif.parse(file, (err, data) => {
 ```js
 const exif = require("jpeg-exif");
 let file = "~/Photo/IMG_0001.JPG";
-let data=exif.parseSync(file);
+let data = exif.parseSync(file);
+console.log(data);
+```
+
+## From Buffer
+
+```js
+const fs = require("fs");
+const exif = require("jpeg-exif");
+const buffer = fs.readFileSync(file);
+const data = exif.fromBuffer(buffer);
 console.log(data);
 ```
 
 ## Features
 
 * Support All CP3451 Standard Tags (Include GPS & SubExif Tags)
-* Support Both Sync & Async Method
+* Support Sync, Async & fromBuffer Method
 
 ## Installation
 


### PR DESCRIPTION
I was looking for the buffer method and found out there exist and exported one which is not documented.
But the [npm package](https://www.npmjs.com/package/jpeg-exif) does not contain `fromBuffer` function so it is helpful if you release a new npm update with buffer support.